### PR TITLE
Add first-class DescriptorSet types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- First-class immutable `driver::descriptor_set::DescriptorSet` allocations with explicit buffer,
+  image, acceleration-structure, and descriptor-copy updates.
+- `PipelineCommand::bind_descriptor_set` for reusing populated descriptor sets in regular graph
+  commands while declaring graph resource accesses separately.
+
+### Changed
+
+- Compatible pipeline variants now share canonical descriptor set layouts and immutable samplers.
+- Supplied descriptor set slots bypass graph-managed descriptor allocation and updates.
+
 ## [0.14.5] - 2026-07-13
 
 ### Added

--- a/examples/bindless.rs
+++ b/examples/bindless.rs
@@ -11,6 +11,7 @@ use {
         driver::{
             DriverError,
             buffer::Buffer,
+            descriptor_set::{DescriptorSet, DescriptorSetInfo, DescriptorSetUpdateInfo},
             device::Device,
             graphics::{GraphicsPipeline, GraphicsPipelineInfo},
             image::{Image, ImageInfo},
@@ -34,6 +35,14 @@ fn main() -> Result<(), WindowError> {
         .build()?;
     let images = create_images(&window.device)?;
     let pipeline = create_graphics_pipeline(&window.device)?;
+    let descriptor_set = DescriptorSet::alloc_and_update(
+        &pipeline,
+        DescriptorSetInfo::builder().set(0).build(),
+        images
+            .iter()
+            .enumerate()
+            .map(|(idx, image)| DescriptorSetUpdateInfo::image((0, [idx as u32]), image)),
+    )?;
     let draw_buf = create_indirect_buffer(&window.device)?;
 
     window.run(|frame| {
@@ -44,12 +53,12 @@ fn main() -> Result<(), WindowError> {
             .begin_cmd()
             .debug_name("Test")
             .bind_pipeline(&pipeline)
+            .bind_descriptor_set(&descriptor_set)
             .resource_access(draw_buf_node, AccessType::IndirectBuffer);
 
-        for (idx, image) in images.iter().enumerate() {
+        for image in &images {
             let image = cmd.bind_resource(image);
-            cmd.set_shader_resource_access(
-                (0, [idx as u32]),
+            cmd.set_resource_access(
                 image,
                 AccessType::FragmentShaderReadSampledImageOrUniformTexelBuffer,
             );

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -331,6 +331,7 @@ impl<'a> Command<'a> {
             last_exec.func = Some(CommandFunction::Once(Box::new(func)));
 
             Execution {
+                descriptor_sets: last_exec.descriptor_sets.clone(),
                 pipeline: last_exec.pipeline.clone(),
                 ..Default::default()
             }
@@ -350,6 +351,7 @@ impl<'a> Command<'a> {
             last_exec.func = Some(CommandFunction::Reusable(Arc::new(func)));
 
             Execution {
+                descriptor_sets: last_exec.descriptor_sets.clone(),
                 pipeline: last_exec.pipeline.clone(),
                 ..Default::default()
             }
@@ -918,11 +920,6 @@ pub struct Binding {
 impl Binding {
     pub(super) fn into_tuple(self) -> (DescriptorSetIndex, BindingIndex, BindingOffset) {
         (self.set, self.binding, self.offset)
-    }
-
-    pub(super) fn set(self) -> DescriptorSetIndex {
-        let (res, _, _) = self.into_tuple();
-        res
     }
 }
 

--- a/src/cmd/pipeline.rs
+++ b/src/cmd/pipeline.rs
@@ -6,7 +6,8 @@ use {
     crate::{
         ExecutionPipeline, TimestampQuery,
         driver::{
-            compute::ComputePipeline, graphics::GraphicsPipeline, ray_tracing::RayTracingPipeline,
+            compute::ComputePipeline, descriptor_set::DescriptorSet, graphics::GraphicsPipeline,
+            ray_tracing::RayTracingPipeline,
         },
     },
     std::marker::PhantomData,
@@ -108,6 +109,42 @@ pub struct PipelineCommand<'c, T> {
 // NOTE: There are specific implementations of T in the compute, graphics, and ray tracing modules
 #[allow(private_bounds)]
 impl<'c, T> PipelineCommand<'c, T> {
+    /// Binds an explicitly populated descriptor set to this and subsequent executions using the
+    /// current pipeline.
+    ///
+    /// This does not declare graph resource accesses. Use [`Self::resource_access`] for every
+    /// resource the recorded work accesses through the set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the descriptor set index does not exist in the current pipeline or its layout is
+    /// incompatible.
+    pub fn bind_descriptor_set(mut self, descriptor_set: &DescriptorSet) -> Self {
+        self.set_descriptor_set(descriptor_set);
+        self
+    }
+
+    /// Mutable-borrow form of [`Self::bind_descriptor_set`].
+    pub fn set_descriptor_set(&mut self, descriptor_set: &DescriptorSet) -> &mut Self {
+        let set = descriptor_set.info().set;
+        let exec = self.cmd.cmd_mut().expect_last_exec_mut();
+        let pipeline = exec.pipeline.as_ref().expect("missing command pipeline");
+        let layout = pipeline
+            .descriptor_info()
+            .layouts
+            .get(&set)
+            .unwrap_or_else(|| panic!("pipeline descriptor set {set} does not exist"));
+
+        assert!(
+            descriptor_set.is_compatible(set, layout),
+            "descriptor set {set} is incompatible with the bound pipeline"
+        );
+
+        exec.descriptor_sets.insert(set, descriptor_set.clone());
+
+        self
+    }
+
     /// Equivalent to [`Command::bind_pipeline`] for a command that already has a bound pipeline.
     pub fn bind_pipeline<P>(self, pipeline: P) -> P::Command
     where

--- a/src/driver/compute.rs
+++ b/src/driver/compute.rs
@@ -6,7 +6,7 @@ use {
         device::Device,
         shader::{DescriptorBindingMap, PipelineDescriptorInfo, Shader},
     },
-    crate::lazy_str,
+    crate::{driver::DescriptorSetLayout, lazy_str},
     ash::vk::{self, Handle as _},
     derive_builder::Builder,
     log::{trace, warn},
@@ -87,7 +87,7 @@ impl ComputePipeline {
         let descriptor_set_layouts = descriptor_info
             .layouts
             .values()
-            .map(|descriptor_set_layout| descriptor_set_layout.handle)
+            .map(DescriptorSetLayout::handle)
             .collect::<Box<_>>();
 
         unsafe {

--- a/src/driver/descriptor_set.rs
+++ b/src/driver/descriptor_set.rs
@@ -1,10 +1,39 @@
-//! Descriptor pool allocation helpers used by pipeline execution.
+//! Explicit descriptor set allocation and update support.
+//!
+//! [`DescriptorSet::alloc_and_update`] creates an immutable descriptor set from a reflected
+//! pipeline layout. The result owns its Vulkan descriptor pool and keeps every resource referenced
+//! by a write or copy alive. Clone it cheaply to reuse the same allocation.
+//!
+//! Descriptor contents do not declare graph synchronization. Bind each referenced resource to the
+//! graph and declare its [`AccessType`](crate::driver::sync::AccessType) separately, then bind the
+//! set with [`PipelineCommand::bind_descriptor_set`](crate::cmd::PipelineCommand::bind_descriptor_set).
+//!
+//! Input attachments, texel buffers, and dynamic buffer descriptors are currently unsupported by
+//! this immutable API and prevent allocating a first-class set for their set index.
 
 use {
-    super::{DescriptorSetLayout, DriverError, device::Device},
+    super::{
+        DescriptorSetLayout, DriverError,
+        accel_struct::AccelerationStructure,
+        buffer::{Buffer, BufferSubresourceRange},
+        compute::ComputePipeline,
+        device::Device,
+        format_aspect_mask,
+        graphics::GraphicsPipeline,
+        image::{Image, ImageViewInfo},
+        ray_tracing::RayTracingPipeline,
+        shader::PipelineDescriptorInfo,
+    },
     ash::vk,
     log::warn,
-    std::{ops::Deref, slice, thread::panicking},
+    std::{
+        fmt::{Debug, Formatter},
+        iter,
+        ops::Deref,
+        slice,
+        sync::Arc,
+        thread::panicking,
+    },
 };
 
 /// Descriptor pool resource used to allocate descriptor sets for pipeline execution.
@@ -44,7 +73,7 @@ impl DescriptorPool {
         let mut pool_sizes = [vk::DescriptorPoolSize {
             ty: Default::default(),
             descriptor_count: 0,
-        }; 11];
+        }; 12];
         let mut pool_size_count = 0;
 
         if info.acceleration_structure_count > 0 {
@@ -155,7 +184,12 @@ impl DescriptorPool {
         .map_err(|err| {
             warn!("unable to create descriptor pool: {err}");
 
-            DriverError::Unsupported
+            match err {
+                vk::Result::ERROR_OUT_OF_DEVICE_MEMORY | vk::Result::ERROR_OUT_OF_HOST_MEMORY => {
+                    DriverError::OutOfMemory
+                }
+                _ => DriverError::Unsupported,
+            }
         })?;
 
         Ok(Self {
@@ -168,7 +202,7 @@ impl DescriptorPool {
     pub(crate) fn allocate_descriptor_set(
         this: &Self,
         layout: &DescriptorSetLayout,
-    ) -> Result<DescriptorSet, DriverError> {
+    ) -> Result<RawDescriptorSet, DriverError> {
         Ok(Self::allocate_descriptor_sets(this, layout, 1)?
             .next()
             .expect("missing descriptor set"))
@@ -179,11 +213,11 @@ impl DescriptorPool {
         &'a self,
         layout: &DescriptorSetLayout,
         count: u32,
-    ) -> Result<impl Iterator<Item = DescriptorSet> + 'a, DriverError> {
-        let mut create_info = vk::DescriptorSetAllocateInfo::default()
+    ) -> Result<impl Iterator<Item = RawDescriptorSet> + 'a, DriverError> {
+        let layout_handles = vec![layout.handle(); count as usize];
+        let create_info = vk::DescriptorSetAllocateInfo::default()
             .descriptor_pool(self.handle)
-            .set_layouts(slice::from_ref(&layout.handle));
-        create_info.descriptor_set_count = count;
+            .set_layouts(&layout_handles);
 
         Ok(unsafe {
             self.device
@@ -202,7 +236,7 @@ impl DescriptorPool {
                     }
                 })?
                 .into_iter()
-                .map(move |descriptor_set| DescriptorSet {
+                .map(move |descriptor_set| RawDescriptorSet {
                     descriptor_pool: self.handle,
                     descriptor_set,
                     device: self.device.clone(),
@@ -246,31 +280,812 @@ pub(crate) struct DescriptorPoolInfo {
 }
 
 impl DescriptorPoolInfo {
-    pub(crate) fn is_empty(&self) -> bool {
-        self.acceleration_structure_count
-            + self.combined_image_sampler_count
-            + self.input_attachment_count
-            + self.sampled_image_count
-            + self.sampler_count
-            + self.storage_buffer_count
-            + self.storage_buffer_dynamic_count
-            + self.storage_image_count
-            + self.storage_texel_buffer_count
-            + self.uniform_buffer_count
-            + self.uniform_buffer_dynamic_count
-            + self.uniform_texel_buffer_count
-            == 0
+    fn for_layout(layout: &DescriptorSetLayout) -> Result<Self, DriverError> {
+        let mut info = Self {
+            max_sets: 1,
+            ..Default::default()
+        };
+
+        for binding in &layout.info().bindings {
+            let count = binding.descriptor_count;
+            let destination = match binding.descriptor_type {
+                vk::DescriptorType::ACCELERATION_STRUCTURE_KHR => {
+                    &mut info.acceleration_structure_count
+                }
+                vk::DescriptorType::COMBINED_IMAGE_SAMPLER => {
+                    &mut info.combined_image_sampler_count
+                }
+                vk::DescriptorType::INPUT_ATTACHMENT => &mut info.input_attachment_count,
+                vk::DescriptorType::SAMPLED_IMAGE => &mut info.sampled_image_count,
+                vk::DescriptorType::SAMPLER => &mut info.sampler_count,
+                vk::DescriptorType::STORAGE_BUFFER => &mut info.storage_buffer_count,
+                vk::DescriptorType::STORAGE_BUFFER_DYNAMIC => {
+                    &mut info.storage_buffer_dynamic_count
+                }
+                vk::DescriptorType::STORAGE_IMAGE => &mut info.storage_image_count,
+                vk::DescriptorType::STORAGE_TEXEL_BUFFER => &mut info.storage_texel_buffer_count,
+                vk::DescriptorType::UNIFORM_BUFFER => &mut info.uniform_buffer_count,
+                vk::DescriptorType::UNIFORM_BUFFER_DYNAMIC => {
+                    &mut info.uniform_buffer_dynamic_count
+                }
+                vk::DescriptorType::UNIFORM_TEXEL_BUFFER => &mut info.uniform_texel_buffer_count,
+                _ => {
+                    warn!(
+                        "unsupported descriptor type {:?} in descriptor set layout",
+                        binding.descriptor_type
+                    );
+                    return Err(DriverError::Unsupported);
+                }
+            };
+            *destination = destination
+                .checked_add(count)
+                .ok_or(DriverError::InvalidData)?;
+        }
+
+        Ok(info)
     }
 }
 
+/// An immutable, explicitly populated Vulkan descriptor set.
+///
+/// The set owns its descriptor pool and every resource referenced by its writes. Cloning this value
+/// shares the same allocation. To change descriptor contents, allocate a new set with
+/// [`Self::alloc_and_update`].
+#[derive(Clone)]
+pub struct DescriptorSet {
+    inner: Arc<DescriptorSetInner>,
+}
+
+impl DescriptorSet {
+    /// Allocates one descriptor set and applies all supplied writes and copies.
+    ///
+    /// `pipeline` supplies the reflected layout selected by [`DescriptorSetInfo::set`]. A single
+    /// [`DescriptorSetUpdateInfo`] or any owned collection of updates may be passed.
+    /// Writes are applied before copies, matching `vkUpdateDescriptorSets` ordering.
+    ///
+    /// Input attachments, texel buffers, and dynamic buffer descriptors are rejected because they
+    /// require render-pass-specific layouts, owned buffer views, or dynamic bind offsets.
+    #[profiling::function]
+    pub fn alloc_and_update<P, I>(
+        pipeline: &P,
+        info: impl Into<DescriptorSetInfo>,
+        updates: I,
+    ) -> Result<Self, DriverError>
+    where
+        P: DescriptorSetPipeline + ?Sized,
+        I: IntoIterator<Item = DescriptorSetUpdateInfo>,
+    {
+        let info = info.into();
+        let pipeline_info = descriptor_set_private::Sealed::descriptor_info(pipeline);
+        let device = descriptor_set_private::Sealed::device(pipeline);
+        let layout = pipeline_info
+            .layouts
+            .get(&info.set)
+            .ok_or_else(|| {
+                warn!("pipeline descriptor set {} does not exist", info.set);
+                DriverError::InvalidData
+            })?
+            .clone();
+        Self::validate_layout(&layout)?;
+        let updates = updates.into_iter().collect::<Vec<_>>();
+        let mut writes = Vec::with_capacity(updates.len());
+        let mut copies = Vec::with_capacity(updates.len());
+
+        for update in updates {
+            let destination_info = Self::validate_binding(&layout, update.destination, 1)?;
+            let descriptor_type = destination_info.descriptor_type;
+
+            match update.update {
+                DescriptorSetUpdate::AccelerationStructure(resource) => {
+                    if descriptor_type != vk::DescriptorType::ACCELERATION_STRUCTURE_KHR
+                        || !Device::is_same(device, &resource.buffer.device)
+                        || !matches!(
+                            resource.info.acceleration_structure_type,
+                            vk::AccelerationStructureTypeKHR::GENERIC
+                                | vk::AccelerationStructureTypeKHR::TOP_LEVEL
+                        )
+                    {
+                        warn!("invalid acceleration structure descriptor write");
+                        return Err(DriverError::InvalidData);
+                    }
+
+                    writes.push(PreparedWrite::AccelerationStructure {
+                        destination: update.destination,
+                        descriptor_type,
+                        resource,
+                    });
+                }
+                DescriptorSetUpdate::Buffer { buffer, range } => {
+                    let (required_usage, required_alignment, max_range) = match descriptor_type {
+                        vk::DescriptorType::STORAGE_BUFFER => (
+                            vk::BufferUsageFlags::STORAGE_BUFFER,
+                            device
+                                .physical
+                                .properties_v1_0
+                                .limits
+                                .min_storage_buffer_offset_alignment,
+                            vk::DeviceSize::from(
+                                device
+                                    .physical
+                                    .properties_v1_0
+                                    .limits
+                                    .max_storage_buffer_range,
+                            ),
+                        ),
+                        vk::DescriptorType::UNIFORM_BUFFER => (
+                            vk::BufferUsageFlags::UNIFORM_BUFFER,
+                            device
+                                .physical
+                                .properties_v1_0
+                                .limits
+                                .min_uniform_buffer_offset_alignment,
+                            vk::DeviceSize::from(
+                                device
+                                    .physical
+                                    .properties_v1_0
+                                    .limits
+                                    .max_uniform_buffer_range,
+                            ),
+                        ),
+                        _ => {
+                            warn!("invalid buffer descriptor type {descriptor_type:?}");
+                            return Err(DriverError::InvalidData);
+                        }
+                    };
+                    let range_size = if range.end == vk::WHOLE_SIZE {
+                        buffer.info.size.saturating_sub(range.start)
+                    } else {
+                        range.end.saturating_sub(range.start)
+                    };
+
+                    if !Device::is_same(device, &buffer.device)
+                        || !buffer.info.usage.contains(required_usage)
+                        || range.start >= buffer.info.size
+                        || range.end != vk::WHOLE_SIZE
+                            && (range.end <= range.start || range.end > buffer.info.size)
+                        || required_alignment > 1 && range.start % required_alignment != 0
+                        || range_size == 0
+                        || range_size > max_range
+                    {
+                        warn!("invalid buffer descriptor write");
+                        return Err(DriverError::InvalidData);
+                    }
+
+                    writes.push(PreparedWrite::Buffer {
+                        destination: update.destination,
+                        descriptor_type,
+                        resource: buffer,
+                        range,
+                    });
+                }
+                DescriptorSetUpdate::Copy {
+                    descriptor_count,
+                    source,
+                    source_binding,
+                } => {
+                    let destination_info =
+                        Self::validate_binding(&layout, update.destination, descriptor_count)?;
+                    let source_info = Self::validate_binding(
+                        &source.inner.layout,
+                        source_binding,
+                        descriptor_count,
+                    )?;
+
+                    if !Device::is_same(device, source.device())
+                        || source_info.descriptor_type != destination_info.descriptor_type
+                        || destination_info.descriptor_type == vk::DescriptorType::SAMPLER
+                            && destination_info.immutable_sampler.is_some()
+                    {
+                        warn!("invalid descriptor copy");
+                        return Err(DriverError::InvalidData);
+                    }
+
+                    copies.push(PreparedCopy {
+                        descriptor_count,
+                        destination: update.destination,
+                        source,
+                        source_binding,
+                    });
+                }
+                DescriptorSetUpdate::Image { image, view } => {
+                    let image_layout = Self::image_layout(descriptor_type).ok_or_else(|| {
+                        warn!("invalid image descriptor write");
+                        DriverError::InvalidData
+                    })?;
+                    let required_usage = match descriptor_type {
+                        vk::DescriptorType::COMBINED_IMAGE_SAMPLER
+                        | vk::DescriptorType::SAMPLED_IMAGE => vk::ImageUsageFlags::SAMPLED,
+                        vk::DescriptorType::STORAGE_IMAGE => vk::ImageUsageFlags::STORAGE,
+                        _ => {
+                            warn!("invalid image descriptor type {descriptor_type:?}");
+                            return Err(DriverError::InvalidData);
+                        }
+                    };
+                    let image_aspects = format_aspect_mask(image.info.format);
+                    let mip_level_count = if view.mip_level_count == vk::REMAINING_MIP_LEVELS {
+                        image
+                            .info
+                            .mip_level_count
+                            .saturating_sub(view.base_mip_level)
+                    } else {
+                        view.mip_level_count
+                    };
+                    let array_layer_count = if view.array_layer_count == vk::REMAINING_ARRAY_LAYERS
+                    {
+                        image
+                            .info
+                            .array_layer_count
+                            .saturating_sub(view.base_array_layer)
+                    } else {
+                        view.array_layer_count
+                    };
+
+                    if !Device::is_same(device, &image.device)
+                        || !image.info.usage.contains(required_usage)
+                        || view.format == vk::Format::UNDEFINED
+                        || view.aspect_mask.as_raw().count_ones() != 1
+                        || !image_aspects.contains(view.aspect_mask)
+                        || view.base_mip_level >= image.info.mip_level_count
+                        || mip_level_count == 0
+                        || mip_level_count > image.info.mip_level_count - view.base_mip_level
+                        || view.base_array_layer >= image.info.array_layer_count
+                        || array_layer_count == 0
+                        || array_layer_count > image.info.array_layer_count - view.base_array_layer
+                        || view.format != image.info.format
+                            && !image
+                                .info
+                                .flags
+                                .contains(vk::ImageCreateFlags::MUTABLE_FORMAT)
+                    {
+                        warn!("invalid image descriptor write");
+                        return Err(DriverError::InvalidData);
+                    }
+
+                    let image_view = image.view(view)?;
+                    writes.push(PreparedWrite::Image {
+                        destination: update.destination,
+                        descriptor_type,
+                        image_layout,
+                        image_view,
+                        resource: image,
+                    });
+                }
+            }
+        }
+
+        let descriptor_pool =
+            DescriptorPool::create(device, DescriptorPoolInfo::for_layout(&layout)?)?;
+        let descriptor_set = DescriptorPool::allocate_descriptor_set(&descriptor_pool, &layout)?;
+        let handle = *descriptor_set;
+
+        for write in &writes {
+            unsafe {
+                match write {
+                    PreparedWrite::AccelerationStructure {
+                        destination,
+                        descriptor_type,
+                        resource,
+                    } => {
+                        let acceleration_structures = [resource.handle];
+                        let mut acceleration_structure_info =
+                            vk::WriteDescriptorSetAccelerationStructureKHR::default()
+                                .acceleration_structures(&acceleration_structures);
+                        let write = vk::WriteDescriptorSet::default()
+                            .dst_set(handle)
+                            .dst_binding(destination.binding)
+                            .dst_array_element(destination.array_element)
+                            .descriptor_type(*descriptor_type)
+                            .descriptor_count(1)
+                            .push_next(&mut acceleration_structure_info);
+                        device.update_descriptor_sets(slice::from_ref(&write), &[]);
+                    }
+                    PreparedWrite::Buffer {
+                        destination,
+                        descriptor_type,
+                        resource,
+                        range,
+                    } => {
+                        let range_size = if range.end == vk::WHOLE_SIZE {
+                            vk::WHOLE_SIZE
+                        } else {
+                            range.end - range.start
+                        };
+                        let buffer_info = vk::DescriptorBufferInfo::default()
+                            .buffer(resource.handle)
+                            .offset(range.start)
+                            .range(range_size);
+                        let write = vk::WriteDescriptorSet::default()
+                            .dst_set(handle)
+                            .dst_binding(destination.binding)
+                            .dst_array_element(destination.array_element)
+                            .descriptor_type(*descriptor_type)
+                            .buffer_info(slice::from_ref(&buffer_info));
+                        device.update_descriptor_sets(slice::from_ref(&write), &[]);
+                    }
+                    PreparedWrite::Image {
+                        destination,
+                        descriptor_type,
+                        image_layout,
+                        image_view,
+                        ..
+                    } => {
+                        let image_info = vk::DescriptorImageInfo::default()
+                            .image_layout(*image_layout)
+                            .image_view(*image_view);
+                        let write = vk::WriteDescriptorSet::default()
+                            .dst_set(handle)
+                            .dst_binding(destination.binding)
+                            .dst_array_element(destination.array_element)
+                            .descriptor_type(*descriptor_type)
+                            .image_info(slice::from_ref(&image_info));
+                        device.update_descriptor_sets(slice::from_ref(&write), &[]);
+                    }
+                }
+            }
+        }
+
+        if !copies.is_empty() {
+            let copy_infos = copies
+                .iter()
+                .map(|copy| {
+                    vk::CopyDescriptorSet::default()
+                        .src_set(copy.source.handle())
+                        .src_binding(copy.source_binding.binding)
+                        .src_array_element(copy.source_binding.array_element)
+                        .dst_set(handle)
+                        .dst_binding(copy.destination.binding)
+                        .dst_array_element(copy.destination.array_element)
+                        .descriptor_count(copy.descriptor_count)
+                })
+                .collect::<Vec<_>>();
+
+            unsafe {
+                device.update_descriptor_sets(&[], &copy_infos);
+            }
+        }
+
+        let resources = writes
+            .into_iter()
+            .map(|write| match write {
+                PreparedWrite::AccelerationStructure { resource, .. } => {
+                    DescriptorSetResource::AccelerationStructure(resource)
+                }
+                PreparedWrite::Buffer { resource, .. } => DescriptorSetResource::Buffer(resource),
+                PreparedWrite::Image { resource, .. } => DescriptorSetResource::Image(resource),
+            })
+            .chain(
+                copies
+                    .into_iter()
+                    .map(|copy| DescriptorSetResource::DescriptorSet(copy.source)),
+            )
+            .collect();
+
+        Ok(Self {
+            inner: Arc::new(DescriptorSetInner {
+                descriptor_set,
+                _descriptor_pool: descriptor_pool,
+                info,
+                layout,
+                _resources: resources,
+            }),
+        })
+    }
+
+    /// The device which owns this descriptor set.
+    pub fn device(&self) -> &Device {
+        self.inner.layout.device()
+    }
+
+    /// The native Vulkan descriptor set handle.
+    pub fn handle(&self) -> vk::DescriptorSet {
+        *self.inner.descriptor_set
+    }
+
+    /// The information used to allocate this descriptor set.
+    pub fn info(&self) -> DescriptorSetInfo {
+        self.inner.info
+    }
+
+    /// Sets the debugging name assigned to this descriptor set.
+    pub fn set_debug_name(&self, name: impl AsRef<str>) {
+        Device::try_set_debug_utils_object_name(self.device(), self.handle(), &name);
+        Device::try_set_private_data_object_name(
+            self.device(),
+            vk::ObjectType::DESCRIPTOR_SET,
+            self.handle(),
+            &name,
+        );
+    }
+
+    pub(crate) fn is_compatible(&self, set: u32, layout: &DescriptorSetLayout) -> bool {
+        self.inner.info.set == set && self.inner.layout.is_same(layout)
+    }
+
+    fn validate_layout(layout: &DescriptorSetLayout) -> Result<(), DriverError> {
+        for binding in &layout.info().bindings {
+            if matches!(
+                binding.descriptor_type,
+                vk::DescriptorType::INPUT_ATTACHMENT
+                    | vk::DescriptorType::STORAGE_BUFFER_DYNAMIC
+                    | vk::DescriptorType::STORAGE_TEXEL_BUFFER
+                    | vk::DescriptorType::UNIFORM_BUFFER_DYNAMIC
+                    | vk::DescriptorType::UNIFORM_TEXEL_BUFFER
+            ) {
+                warn!(
+                    "descriptor set layout contains unsupported descriptor type {:?}",
+                    binding.descriptor_type
+                );
+                return Err(DriverError::Unsupported);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn image_layout(descriptor_type: vk::DescriptorType) -> Option<vk::ImageLayout> {
+        match descriptor_type {
+            vk::DescriptorType::COMBINED_IMAGE_SAMPLER | vk::DescriptorType::SAMPLED_IMAGE => {
+                Some(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
+            }
+            vk::DescriptorType::STORAGE_IMAGE => Some(vk::ImageLayout::GENERAL),
+            _ => None,
+        }
+    }
+
+    fn validate_binding(
+        layout: &DescriptorSetLayout,
+        binding: DescriptorSetBinding,
+        descriptor_count: u32,
+    ) -> Result<&super::descriptor_set_layout::DescriptorSetLayoutBindingInfo, DriverError> {
+        let binding_info = layout.info().binding(binding.binding).ok_or_else(|| {
+            warn!("descriptor binding {} does not exist", binding.binding);
+            DriverError::InvalidData
+        })?;
+        let end = binding
+            .array_element
+            .checked_add(descriptor_count)
+            .ok_or(DriverError::InvalidData)?;
+
+        if descriptor_count == 0 || end > binding_info.descriptor_count {
+            warn!(
+                "descriptor binding {} array range {}..{} is out of bounds",
+                binding.binding, binding.array_element, end
+            );
+            return Err(DriverError::InvalidData);
+        }
+
+        Ok(binding_info)
+    }
+}
+
+impl Debug for DescriptorSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut result = f.debug_struct(stringify!(DescriptorSet));
+
+        if let Some(debug_name) = &Device::private_data_object_name(
+            self.device(),
+            vk::ObjectType::DESCRIPTOR_SET,
+            self.handle(),
+        ) {
+            result.field("debug_name", debug_name);
+        }
+
+        result
+            .field("handle", &self.handle())
+            .field("info", &self.info())
+            .finish()
+    }
+}
+
+/// Identifies one binding and array element within a descriptor set.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct DescriptorSetBinding {
+    /// The descriptor binding index.
+    pub binding: u32,
+
+    /// The array element within `binding`.
+    pub array_element: u32,
+}
+
+impl From<u32> for DescriptorSetBinding {
+    fn from(binding: u32) -> Self {
+        Self {
+            binding,
+            array_element: 0,
+        }
+    }
+}
+
+impl From<(u32, u32)> for DescriptorSetBinding {
+    fn from((binding, array_element): (u32, u32)) -> Self {
+        Self {
+            binding,
+            array_element,
+        }
+    }
+}
+
+impl From<(u32, [u32; 1])> for DescriptorSetBinding {
+    fn from((binding, [array_element]): (u32, [u32; 1])) -> Self {
+        Self {
+            binding,
+            array_element,
+        }
+    }
+}
+
+/// Information used to allocate a [`DescriptorSet`].
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct DescriptorSetInfo {
+    /// The pipeline descriptor set index whose layout will be used.
+    pub set: u32,
+}
+
+impl DescriptorSetInfo {
+    /// Creates a default descriptor set information builder.
+    pub const fn builder() -> DescriptorSetInfoBuilder {
+        DescriptorSetInfoBuilder { set: 0 }
+    }
+
+    /// Converts this information into a builder.
+    pub const fn into_builder(self) -> DescriptorSetInfoBuilder {
+        DescriptorSetInfoBuilder { set: self.set }
+    }
+}
+
+impl From<DescriptorSetInfoBuilder> for DescriptorSetInfo {
+    fn from(info: DescriptorSetInfoBuilder) -> Self {
+        info.build()
+    }
+}
+
+/// Builder for [`DescriptorSetInfo`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DescriptorSetInfoBuilder {
+    set: u32,
+}
+
+impl DescriptorSetInfoBuilder {
+    /// Selects the pipeline descriptor set index whose layout will be used.
+    pub const fn set(mut self, set: u32) -> Self {
+        self.set = set;
+        self
+    }
+
+    /// Builds descriptor set information.
+    pub const fn build(self) -> DescriptorSetInfo {
+        DescriptorSetInfo { set: self.set }
+    }
+}
+
+struct DescriptorSetInner {
+    descriptor_set: RawDescriptorSet,
+    _descriptor_pool: DescriptorPool,
+    info: DescriptorSetInfo,
+    layout: DescriptorSetLayout,
+    _resources: Box<[DescriptorSetResource]>,
+}
+
+impl Drop for DescriptorSetInner {
+    fn drop(&mut self) {
+        if panicking() {
+            return;
+        }
+
+        Device::try_clear_private_data_object_name(
+            self.layout.device(),
+            vk::ObjectType::DESCRIPTOR_SET,
+            *self.descriptor_set,
+        );
+    }
+}
+
+#[allow(dead_code)]
+enum DescriptorSetResource {
+    AccelerationStructure(Arc<AccelerationStructure>),
+    Buffer(Arc<Buffer>),
+    DescriptorSet(DescriptorSet),
+    Image(Arc<Image>),
+}
+
+#[derive(Clone, Debug)]
+enum DescriptorSetUpdate {
+    AccelerationStructure(Arc<AccelerationStructure>),
+    Buffer {
+        buffer: Arc<Buffer>,
+        range: BufferSubresourceRange,
+    },
+    Copy {
+        descriptor_count: u32,
+        source: DescriptorSet,
+        source_binding: DescriptorSetBinding,
+    },
+    Image {
+        image: Arc<Image>,
+        view: ImageViewInfo,
+    },
+}
+
+/// One write or copy performed while allocating a [`DescriptorSet`].
+#[derive(Clone, Debug)]
+pub struct DescriptorSetUpdateInfo {
+    destination: DescriptorSetBinding,
+    update: DescriptorSetUpdate,
+}
+
+impl DescriptorSetUpdateInfo {
+    /// Writes an acceleration structure descriptor.
+    pub fn acceleration_structure(
+        destination: impl Into<DescriptorSetBinding>,
+        acceleration_structure: &Arc<AccelerationStructure>,
+    ) -> Self {
+        Self {
+            destination: destination.into(),
+            update: DescriptorSetUpdate::AccelerationStructure(acceleration_structure.clone()),
+        }
+    }
+
+    /// Writes a whole-buffer descriptor.
+    pub fn buffer(destination: impl Into<DescriptorSetBinding>, buffer: &Arc<Buffer>) -> Self {
+        Self::buffer_range(destination, buffer, buffer.info)
+    }
+
+    /// Writes a descriptor for a range of a buffer.
+    pub fn buffer_range(
+        destination: impl Into<DescriptorSetBinding>,
+        buffer: &Arc<Buffer>,
+        range: impl Into<BufferSubresourceRange>,
+    ) -> Self {
+        Self {
+            destination: destination.into(),
+            update: DescriptorSetUpdate::Buffer {
+                buffer: buffer.clone(),
+                range: range.into(),
+            },
+        }
+    }
+
+    /// Copies one descriptor from an existing descriptor set.
+    pub fn copy(
+        source: &DescriptorSet,
+        source_binding: impl Into<DescriptorSetBinding>,
+        destination: impl Into<DescriptorSetBinding>,
+    ) -> Self {
+        Self::copy_many(source, source_binding, destination, 1)
+    }
+
+    /// Copies consecutive descriptors from an existing descriptor set.
+    ///
+    /// The source and destination ranges must each remain within one reflected binding.
+    pub fn copy_many(
+        source: &DescriptorSet,
+        source_binding: impl Into<DescriptorSetBinding>,
+        destination: impl Into<DescriptorSetBinding>,
+        descriptor_count: u32,
+    ) -> Self {
+        Self {
+            destination: destination.into(),
+            update: DescriptorSetUpdate::Copy {
+                descriptor_count,
+                source: source.clone(),
+                source_binding: source_binding.into(),
+            },
+        }
+    }
+
+    /// Writes a descriptor using the image's default view.
+    ///
+    /// Depth/stencil formats require [`Self::image_view`] with exactly one selected aspect.
+    pub fn image(destination: impl Into<DescriptorSetBinding>, image: &Arc<Image>) -> Self {
+        Self::image_view(destination, image, image.info)
+    }
+
+    /// Writes a descriptor using a specific image view.
+    pub fn image_view(
+        destination: impl Into<DescriptorSetBinding>,
+        image: &Arc<Image>,
+        view: impl Into<ImageViewInfo>,
+    ) -> Self {
+        Self {
+            destination: destination.into(),
+            update: DescriptorSetUpdate::Image {
+                image: image.clone(),
+                view: view.into(),
+            },
+        }
+    }
+}
+
+impl IntoIterator for DescriptorSetUpdateInfo {
+    type Item = Self;
+    type IntoIter = iter::Once<Self>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self)
+    }
+}
+
+impl IntoIterator for &DescriptorSetUpdateInfo {
+    type Item = DescriptorSetUpdateInfo;
+    type IntoIter = iter::Once<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        iter::once(self.clone())
+    }
+}
+
+/// A compute, graphics, or ray tracing pipeline that can provide a descriptor set layout.
+#[doc(hidden)]
+pub trait DescriptorSetPipeline: descriptor_set_private::Sealed {}
+
+macro_rules! descriptor_set_pipeline {
+    ($pipeline:ty) => {
+        #[allow(private_interfaces)]
+        impl descriptor_set_private::Sealed for $pipeline {
+            fn descriptor_info(&self) -> &PipelineDescriptorInfo {
+                &self.inner.descriptor_info
+            }
+
+            fn device(&self) -> &Device {
+                self.device()
+            }
+        }
+
+        impl DescriptorSetPipeline for $pipeline {}
+    };
+}
+
+descriptor_set_pipeline!(ComputePipeline);
+descriptor_set_pipeline!(GraphicsPipeline);
+descriptor_set_pipeline!(RayTracingPipeline);
+
+#[allow(private_interfaces)]
+mod descriptor_set_private {
+    use super::{Device, PipelineDescriptorInfo};
+
+    pub trait Sealed {
+        fn descriptor_info(&self) -> &PipelineDescriptorInfo;
+
+        fn device(&self) -> &Device;
+    }
+}
+
+enum PreparedWrite {
+    AccelerationStructure {
+        destination: DescriptorSetBinding,
+        descriptor_type: vk::DescriptorType,
+        resource: Arc<AccelerationStructure>,
+    },
+    Buffer {
+        destination: DescriptorSetBinding,
+        descriptor_type: vk::DescriptorType,
+        resource: Arc<Buffer>,
+        range: BufferSubresourceRange,
+    },
+    Image {
+        destination: DescriptorSetBinding,
+        descriptor_type: vk::DescriptorType,
+        image_layout: vk::ImageLayout,
+        image_view: vk::ImageView,
+        resource: Arc<Image>,
+    },
+}
+
+struct PreparedCopy {
+    descriptor_count: u32,
+    destination: DescriptorSetBinding,
+    source: DescriptorSet,
+    source_binding: DescriptorSetBinding,
+}
+
 #[derive(Debug)]
-pub(crate) struct DescriptorSet {
+pub(crate) struct RawDescriptorSet {
     descriptor_pool: vk::DescriptorPool,
     descriptor_set: vk::DescriptorSet,
     device: Device,
 }
 
-impl Deref for DescriptorSet {
+impl Deref for RawDescriptorSet {
     type Target = vk::DescriptorSet;
 
     fn deref(&self) -> &Self::Target {
@@ -278,7 +1093,7 @@ impl Deref for DescriptorSet {
     }
 }
 
-impl Drop for DescriptorSet {
+impl Drop for RawDescriptorSet {
     #[profiling::function]
     fn drop(&mut self) {
         if panicking() {
@@ -291,5 +1106,50 @@ impl Drop for DescriptorSet {
         } {
             warn!("unable to free descriptor set: {err}");
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn descriptor_set_binding_conversions() {
+        assert_eq!(
+            DescriptorSetBinding::from(3),
+            DescriptorSetBinding {
+                binding: 3,
+                array_element: 0,
+            }
+        );
+        assert_eq!(
+            DescriptorSetBinding::from((3, [7])),
+            DescriptorSetBinding {
+                binding: 3,
+                array_element: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn descriptor_set_info_builder() {
+        let info = DescriptorSetInfo::builder().set(2).build();
+
+        assert_eq!(info.set, 2);
+        assert_eq!(info, info.into_builder().build());
+        assert_eq!(
+            std::mem::size_of::<DescriptorSetInfo>(),
+            std::mem::size_of::<u32>()
+        );
+    }
+
+    #[test]
+    fn empty_descriptor_set_updates_are_inferred() {
+        fn update_count(updates: impl IntoIterator<Item = DescriptorSetUpdateInfo>) -> usize {
+            updates.into_iter().count()
+        }
+
+        assert_eq!(update_count([]), 0);
+        assert_eq!(update_count(None), 0);
     }
 }

--- a/src/driver/descriptor_set.rs
+++ b/src/driver/descriptor_set.rs
@@ -697,6 +697,13 @@ impl DescriptorSet {
         );
     }
 
+    /// Sets the debugging name assigned to this descriptor set.
+    pub fn with_debug_name(self, name: impl AsRef<str>) -> Self {
+        self.set_debug_name(name);
+
+        self
+    }
+
     pub(crate) fn is_compatible(&self, set: u32, layout: &DescriptorSetLayout) -> bool {
         self.inner.info.set == set && self.inner.layout.is_same(layout)
     }
@@ -814,7 +821,9 @@ impl From<(u32, [u32; 1])> for DescriptorSetBinding {
     }
 }
 
-/// Information used to allocate a [`DescriptorSet`].
+/// Information selecting the pipeline layout used to allocate a [`DescriptorSet`].
+///
+/// Descriptor contents are supplied separately through [`DescriptorSetUpdateInfo`] values.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct DescriptorSetInfo {
     /// The pipeline descriptor set index whose layout will be used.

--- a/src/driver/descriptor_set_layout.rs
+++ b/src/driver/descriptor_set_layout.rs
@@ -1,46 +1,143 @@
 use {
-    super::{DriverError, device::Device},
+    super::{
+        DriverError,
+        device::Device,
+        shader::{Sampler, SamplerInfo},
+    },
     ash::vk,
     log::warn,
     std::{
+        collections::{HashMap, hash_map::Entry},
         fmt::{Debug, Formatter},
+        ops::Deref,
+        sync::{Arc, Mutex, OnceLock, Weak},
         thread::panicking,
     },
 };
 
-#[read_only::cast]
-pub struct DescriptorSetLayout {
-    pub device: Device,
-    pub handle: vk::DescriptorSetLayout,
+#[derive(Clone)]
+pub(crate) struct DescriptorSetLayout {
+    inner: Arc<DescriptorSetLayoutInner>,
 }
 
 impl DescriptorSetLayout {
     #[profiling::function]
-    pub fn create(
+    pub(crate) fn get_or_create(
         device: &Device,
-        info: &vk::DescriptorSetLayoutCreateInfo,
+        info: DescriptorSetLayoutInfo,
     ) -> Result<Self, DriverError> {
-        let device = device.clone();
+        type Cache = HashMap<(usize, DescriptorSetLayoutInfo), Weak<DescriptorSetLayoutInner>>;
+
+        static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+
+        let cache = CACHE.get_or_init(Default::default);
+        let mut cache = cache.lock().expect("poisoned descriptor set layout cache");
+        cache.retain(|_, layout| layout.strong_count() != 0);
+        let key = (Device::identity(device), info.clone());
+        if let Some(inner) = cache.get(&key).and_then(Weak::upgrade) {
+            return Ok(Self { inner });
+        }
+
+        let mut samplers = HashMap::<SamplerInfo, Sampler>::new();
+        for binding in &info.bindings {
+            let Some(sampler_info) = binding.immutable_sampler else {
+                continue;
+            };
+
+            if let Entry::Vacant(entry) = samplers.entry(sampler_info) {
+                entry.insert(Sampler::create(device, sampler_info)?);
+            }
+        }
+
+        let immutable_samplers = info
+            .bindings
+            .iter()
+            .map(|binding| {
+                binding.immutable_sampler.map(|sampler_info| {
+                    let sampler = *samplers
+                        .get(&sampler_info)
+                        .expect("missing immutable sampler")
+                        .deref();
+                    vec![sampler; binding.descriptor_count as usize].into_boxed_slice()
+                })
+            })
+            .collect::<Box<_>>();
+        let bindings = info
+            .bindings
+            .iter()
+            .enumerate()
+            .map(|(index, binding)| {
+                let binding_info = vk::DescriptorSetLayoutBinding::default()
+                    .binding(binding.binding)
+                    .descriptor_count(binding.descriptor_count)
+                    .descriptor_type(binding.descriptor_type)
+                    .stage_flags(binding.stage_flags);
+
+                if let Some(immutable_samplers) = immutable_samplers[index].as_deref() {
+                    binding_info.immutable_samplers(immutable_samplers)
+                } else {
+                    binding_info
+                }
+            })
+            .collect::<Box<_>>();
+        let binding_flags = info
+            .bindings
+            .iter()
+            .map(|binding| binding.binding_flags)
+            .collect::<Box<_>>();
+        let mut binding_flags_info =
+            vk::DescriptorSetLayoutBindingFlagsCreateInfo::default().binding_flags(&binding_flags);
+        let mut create_info = vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings);
+        if binding_flags.iter().any(|flags| !flags.is_empty()) {
+            create_info = create_info.push_next(&mut binding_flags_info);
+        }
+
         let handle = unsafe {
             device
-                .create_descriptor_set_layout(info, None)
+                .create_descriptor_set_layout(&create_info, None)
                 .map_err(|err| {
                     warn!("unable to create descriptor set layout: {err}");
+                    match err {
+                        vk::Result::ERROR_OUT_OF_DEVICE_MEMORY
+                        | vk::Result::ERROR_OUT_OF_HOST_MEMORY => DriverError::OutOfMemory,
+                        _ => DriverError::Unsupported,
+                    }
+                })?
+        };
+        let inner = Arc::new(DescriptorSetLayoutInner {
+            device: device.clone(),
+            handle,
+            info,
+            samplers: samplers.into_values().collect(),
+        });
 
-                    DriverError::Unsupported
-                })
-        }?;
+        cache.insert(key, Arc::downgrade(&inner));
 
-        Ok(Self { device, handle })
+        Ok(Self { inner })
     }
 
-    /// Sets the debugging name assigned to this descriptor set layout.
-    pub fn set_debug_name(&self, name: impl AsRef<str>) {
-        Device::try_set_debug_utils_object_name(&self.device, self.handle, &name);
+    pub(crate) fn device(&self) -> &Device {
+        &self.inner.device
+    }
+
+    pub(crate) fn handle(&self) -> vk::DescriptorSetLayout {
+        self.inner.handle
+    }
+
+    pub(crate) fn info(&self) -> &DescriptorSetLayoutInfo {
+        &self.inner.info
+    }
+
+    pub(crate) fn is_same(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    pub(crate) fn set_debug_name(&self, name: impl AsRef<str>) {
+        Device::try_set_debug_utils_object_name(&self.inner.device, self.inner.handle, &name);
         Device::try_set_private_data_object_name(
-            &self.device,
+            &self.inner.device,
             vk::ObjectType::DESCRIPTOR_SET_LAYOUT,
-            self.handle,
+            self.inner.handle,
             &name,
         );
     }
@@ -48,21 +145,62 @@ impl DescriptorSetLayout {
 
 impl Debug for DescriptorSetLayout {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut res = f.debug_struct(stringify!(DescriptorSetLayout));
+        let mut result = f.debug_struct(stringify!(DescriptorSetLayout));
 
         if let Some(debug_name) = &Device::private_data_object_name(
-            &self.device,
+            &self.inner.device,
             vk::ObjectType::DESCRIPTOR_SET_LAYOUT,
-            self.handle,
+            self.inner.handle,
         ) {
-            res.field("debug_name", debug_name);
+            result.field("debug_name", debug_name);
         }
 
-        res.field("handle", &self.handle).finish()
+        result.field("handle", &self.inner.handle).finish()
     }
 }
 
-impl Drop for DescriptorSetLayout {
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct DescriptorSetLayoutBindingInfo {
+    pub binding: u32,
+    pub binding_flags: vk::DescriptorBindingFlags,
+    pub descriptor_count: u32,
+    pub descriptor_type: vk::DescriptorType,
+    pub immutable_sampler: Option<SamplerInfo>,
+    pub stage_flags: vk::ShaderStageFlags,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct DescriptorSetLayoutInfo {
+    pub bindings: Box<[DescriptorSetLayoutBindingInfo]>,
+}
+
+impl DescriptorSetLayoutInfo {
+    pub fn binding(&self, binding: u32) -> Option<&DescriptorSetLayoutBindingInfo> {
+        self.bindings
+            .binary_search_by_key(&binding, |info| info.binding)
+            .ok()
+            .map(|index| &self.bindings[index])
+    }
+}
+
+struct DescriptorSetLayoutInner {
+    device: Device,
+    handle: vk::DescriptorSetLayout,
+    info: DescriptorSetLayoutInfo,
+    samplers: Box<[Sampler]>,
+}
+
+impl Debug for DescriptorSetLayoutInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!(DescriptorSetLayoutInner))
+            .field("handle", &self.handle)
+            .field("info", &self.info)
+            .field("samplers", &self.samplers)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for DescriptorSetLayoutInner {
     #[profiling::function]
     fn drop(&mut self) {
         if panicking() {

--- a/src/driver/device.rs
+++ b/src/driver/device.rs
@@ -424,6 +424,10 @@ impl Device {
         Arc::ptr_eq(&lhs.inner, &rhs.inner)
     }
 
+    pub(crate) fn identity(this: &Self) -> usize {
+        Arc::as_ptr(&this.inner) as usize
+    }
+
     /// Returns the device-owned pipeline cache handle.
     pub(crate) fn pipeline_cache(this: &Self) -> vk::PipelineCache {
         this.inner.pipeline_cache

--- a/src/driver/graphics.rs
+++ b/src/driver/graphics.rs
@@ -8,7 +8,7 @@ use {
         merge_push_constant_ranges,
         shader::{DescriptorBindingMap, PipelineDescriptorInfo, Shader, SpecializationMap},
     },
-    crate::lazy_str,
+    crate::{driver::DescriptorSetLayout, lazy_str},
     ash::vk,
     derive_builder::Builder,
     log::{Level::Trace, log_enabled, trace, warn},
@@ -488,7 +488,7 @@ impl GraphicsPipeline {
         let descriptor_sets_layouts = descriptor_info
             .layouts
             .values()
-            .map(|descriptor_set_layout| descriptor_set_layout.handle)
+            .map(DescriptorSetLayout::handle)
             .collect::<Box<_>>();
 
         let push_constants = shaders

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! - [`AccelerationStructure`](accel_struct::AccelerationStructure)
 //! - [`Buffer`]
+//! - [`DescriptorSet`](descriptor_set::DescriptorSet)
 //! - [`Image`](image::Image)
 //!
 //! Resources are logically mutable. All resource types contain useful read-only public fields, for
@@ -47,6 +48,7 @@ pub mod accel_struct;
 pub mod buffer;
 pub mod cmd_buf;
 pub mod compute;
+pub mod descriptor_set;
 pub mod device;
 pub mod fence;
 pub mod graphics;
@@ -59,7 +61,6 @@ pub mod shader;
 pub mod surface;
 pub mod swapchain;
 
-pub(crate) mod descriptor_set;
 pub(crate) mod query_pool;
 
 mod descriptor_set_layout;
@@ -90,7 +91,7 @@ pub use ash::{self};
 pub use vk_sync::{self as sync};
 
 pub(crate) use self::{
-    descriptor_set::DescriptorSet,
+    descriptor_set::RawDescriptorSet,
     descriptor_set_layout::DescriptorSetLayout,
     render_pass::{
         AttachmentInfo, AttachmentRef, FramebufferAttachmentImageInfo, FramebufferInfo,

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -12,7 +12,7 @@
 //! - [`DescriptorSet`](descriptor_set::DescriptorSet)
 //! - [`Image`](image::Image)
 //!
-//! Resources are logically mutable. All resource types contain useful read-only public fields, for
+//! Graph-tracked resources are logically mutable and contain useful read-only public fields, for
 //! example:
 //!
 //! | [`Buffer`] field | Type |
@@ -21,8 +21,11 @@
 //! | [`handle`](Buffer::handle) | [`vk::Buffer`] |
 //! | [`info`](Buffer::info) | [`BufferInfo`] |
 //!
-//! Resources use atomic [`AccessType`](sync::AccessType) values to maintain consistency and track
-//! changes.
+//! [`DescriptorSet`](descriptor_set::DescriptorSet) is instead a shared immutable wrapper and
+//! exposes the same information through `device()`, `handle()`, and `info()` methods.
+//!
+//! Graph-tracked resources use atomic [`AccessType`](sync::AccessType) values to maintain
+//! consistency and track changes. Descriptor contents do not declare graph synchronization.
 //!
 //! # Pipelines
 //!

--- a/src/driver/ray_tracing.rs
+++ b/src/driver/ray_tracing.rs
@@ -8,7 +8,7 @@ use {
         physical_device::khr::RayTracingPipelineProperties,
         shader::{DescriptorBindingMap, PipelineDescriptorInfo, Shader},
     },
-    crate::lazy_str,
+    crate::{driver::DescriptorSetLayout, lazy_str},
     ash::vk::{self, Handle},
     derive_builder::Builder,
     log::warn,
@@ -139,7 +139,7 @@ impl RayTracingPipeline {
         let layouts = descriptor_info
             .layouts
             .values()
-            .map(|layout| layout.handle)
+            .map(DescriptorSetLayout::handle)
             .collect::<Box<_>>();
 
         unsafe {

--- a/src/driver/shader.rs
+++ b/src/driver/shader.rs
@@ -94,7 +94,11 @@
 //! [`Shader`] values around only as long as they are useful to construct or rebuild pipelines.
 
 use {
-    super::{DescriptorSetLayout, DriverError, VertexInputState, device::Device},
+    super::{
+        DescriptorSetLayout, DriverError, VertexInputState,
+        descriptor_set_layout::{DescriptorSetLayoutBindingInfo, DescriptorSetLayoutInfo},
+        device::Device,
+    },
     ash::vk,
     derive_builder::{Builder, UninitializedFieldError},
     log::{debug, error, trace, warn},
@@ -110,7 +114,6 @@ use {
     std::{
         collections::{BTreeMap, HashMap},
         fmt::{Debug, Formatter},
-        iter::repeat_n,
         ops::Deref,
         panic::{AssertUnwindSafe, catch_unwind},
         thread::panicking,
@@ -272,9 +275,6 @@ impl DescriptorInfo {
 pub(crate) struct PipelineDescriptorInfo {
     pub layouts: BTreeMap<u32, DescriptorSetLayout>,
     pub pool_sizes: HashMap<u32, HashMap<vk::DescriptorType, u32>>,
-
-    #[allow(dead_code)]
-    samplers: Box<[Sampler]>,
 }
 
 impl PipelineDescriptorInfo {
@@ -294,47 +294,6 @@ impl PipelineDescriptorInfo {
 
         //trace!("descriptor_bindings: {:#?}", &descriptor_bindings);
 
-        let mut sampler_info_binding_count = HashMap::<_, u32>::with_capacity(
-            descriptor_bindings
-                .values()
-                .filter(|(descriptor_info, _)| descriptor_info.sampler_info().is_some())
-                .count(),
-        );
-
-        for (sampler_info, binding_count) in
-            descriptor_bindings
-                .values()
-                .filter_map(|(descriptor_info, _)| {
-                    descriptor_info
-                        .sampler_info()
-                        .map(|sampler_info| (sampler_info, descriptor_info.binding_count()))
-                })
-        {
-            sampler_info_binding_count
-                .entry(sampler_info)
-                .and_modify(|sampler_info_binding_count| {
-                    *sampler_info_binding_count = binding_count.max(*sampler_info_binding_count);
-                })
-                .or_insert(binding_count);
-        }
-
-        let mut samplers = sampler_info_binding_count
-            .keys()
-            .copied()
-            .map(|sampler_info| {
-                Sampler::create(device, sampler_info).map(|sampler| (sampler_info, sampler))
-            })
-            .collect::<Result<HashMap<_, _>, _>>()?;
-        let immutable_samplers = sampler_info_binding_count
-            .iter()
-            .map(|(sampler_info, &binding_count)| {
-                (
-                    *sampler_info,
-                    repeat_n(*samplers[sampler_info], binding_count as _).collect::<Box<_>>(),
-                )
-            })
-            .collect::<HashMap<_, _>>();
-
         for descriptor_set_idx in 0..descriptor_set_count {
             let mut binding_counts = HashMap::<vk::DescriptorType, u32>::new();
             let mut bindings = vec![];
@@ -346,23 +305,25 @@ impl PipelineDescriptorInfo {
                 let descriptor_ty = descriptor_info.descriptor_type();
                 *binding_counts.entry(descriptor_ty).or_default() +=
                     descriptor_info.binding_count();
-                let mut binding = vk::DescriptorSetLayoutBinding::default()
-                    .binding(descriptor.binding)
-                    .descriptor_count(descriptor_info.binding_count())
-                    .descriptor_type(descriptor_ty)
-                    .stage_flags(*stage_flags);
-
-                if let Some(immutable_samplers) =
-                    descriptor_info.sampler_info().map(|sampler_info| {
-                        &immutable_samplers[&sampler_info]
-                            [0..descriptor_info.binding_count() as usize]
-                    })
-                {
-                    binding = binding.immutable_samplers(immutable_samplers);
-                }
-
-                bindings.push(binding);
+                bindings.push(DescriptorSetLayoutBindingInfo {
+                    binding: descriptor.binding,
+                    binding_flags: if device
+                        .physical
+                        .features_v1_2
+                        .descriptor_binding_partially_bound
+                    {
+                        vk::DescriptorBindingFlags::PARTIALLY_BOUND
+                    } else {
+                        vk::DescriptorBindingFlags::empty()
+                    },
+                    descriptor_count: descriptor_info.binding_count(),
+                    descriptor_type: descriptor_ty,
+                    immutable_sampler: descriptor_info.sampler_info(),
+                    stage_flags: *stage_flags,
+                });
             }
+
+            bindings.sort_unstable_by_key(|binding| binding.binding);
 
             let pool_size = pool_sizes
                 .entry(descriptor_set_idx)
@@ -372,42 +333,16 @@ impl PipelineDescriptorInfo {
                 *pool_size.entry(descriptor_ty).or_default() += binding_count;
             }
 
-            //trace!("bindings: {:#?}", &bindings);
-
-            let mut create_info = vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings);
-
-            /*
-            The bindless flags have to be created for every descriptor set layout binding.
-            See [`VkDescriptorSetLayoutBindingFlagsCreateInfo`](https://registry.khronos.org/vulkan/specs/latest/man/html/VkDescriptorSetLayoutBindingFlagsCreateInfo.html)
-            Maybe using one vector and updating it would be more efficient.
-            */
-            let bindless_flags = vec![vk::DescriptorBindingFlags::PARTIALLY_BOUND; bindings.len()];
-            let mut bindless_flags = if device
-                .physical
-                .features_v1_2
-                .descriptor_binding_partially_bound
-            {
-                let bindless_flags = vk::DescriptorSetLayoutBindingFlagsCreateInfo::default()
-                    .binding_flags(&bindless_flags);
-                Some(bindless_flags)
-            } else {
-                None
-            };
-
-            if let Some(bindless_flags) = bindless_flags.as_mut() {
-                create_info = create_info.push_next(bindless_flags);
-            }
-
             layouts.insert(
                 descriptor_set_idx,
-                DescriptorSetLayout::create(device, &create_info)?,
+                DescriptorSetLayout::get_or_create(
+                    device,
+                    DescriptorSetLayoutInfo {
+                        bindings: bindings.into_boxed_slice(),
+                    },
+                )?,
             );
         }
-
-        let samplers = samplers
-            .drain()
-            .map(|(_, sampler)| sampler)
-            .collect::<Box<_>>();
 
         //trace!("layouts {:#?}", &layouts);
         // trace!("pool_sizes {:#?}", &pool_sizes);
@@ -415,7 +350,6 @@ impl PipelineDescriptorInfo {
         Ok(Self {
             layouts,
             pool_sizes,
-            samplers,
         })
     }
 }

--- a/src/driver/shader.rs
+++ b/src/driver/shader.rs
@@ -308,10 +308,11 @@ impl PipelineDescriptorInfo {
                     descriptor_info.binding_count();
                 bindings.push(DescriptorSetLayoutBindingInfo {
                     binding: descriptor.binding,
-                    binding_flags: if device
-                        .physical
-                        .features_v1_2
-                        .descriptor_binding_partially_bound
+                    binding_flags: if bindless_descriptors.contains(descriptor)
+                        && device
+                            .physical
+                            .features_v1_2
+                            .descriptor_binding_partially_bound
                     {
                         vk::DescriptorBindingFlags::PARTIALLY_BOUND
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use {
             accel_struct::AccelerationStructureInfo,
             buffer::BufferInfo,
             compute::ComputePipeline,
+            descriptor_set::DescriptorSet,
             format_aspect_mask,
             graphics::{DepthStencilInfo, GraphicsPipeline},
             image::{ImageInfo, ImageViewInfo, SampleCount},
@@ -562,16 +563,16 @@ impl CommandData {
     fn descriptor_pools_sizes(
         &self,
     ) -> impl Iterator<Item = impl Iterator<Item = (&vk::DescriptorType, &u32)>> {
-        self.execs
-            .iter()
-            .flat_map(|exec| &exec.pipeline)
-            .map(|pipeline| {
+        self.execs.iter().flat_map(|exec| {
+            exec.pipeline.iter().map(move |pipeline| {
                 pipeline
                     .descriptor_info()
                     .pool_sizes
-                    .values()
-                    .flat_map(HashMap::iter)
+                    .iter()
+                    .filter(move |(set, _)| !exec.descriptor_sets.contains_key(set))
+                    .flat_map(|(_, pool)| pool.iter())
             })
+        })
     }
 
     fn expect_first_exec(&self) -> &Execution {
@@ -834,6 +835,7 @@ struct Execution {
     accesses: ExecutionAccess,
     attachments: ExecutionAttachmentMap,
     bindings: BTreeMap<Binding, (NodeIndex, ViewInfo)>,
+    descriptor_sets: BTreeMap<u32, DescriptorSet>,
 
     correlated_view_mask: u32,
     depth_stencil: Option<DepthStencilInfo>,
@@ -870,6 +872,7 @@ impl Debug for Execution {
             .field("accesses", &self.accesses)
             .field("attachments", &self.attachments)
             .field("bindings", &self.bindings)
+            .field("descriptor_sets", &self.descriptor_sets)
             .field("correlated_view_mask", &self.correlated_view_mask)
             .field("depth_stencil", &self.depth_stencil)
             .field("render_area", &self.render_area)

--- a/src/submission.rs
+++ b/src/submission.rs
@@ -26,13 +26,13 @@ use {
         StoreOp, TimestampQuery,
         cmd::CommandRef,
         driver::{
-            AttachmentInfo, AttachmentRef, Descriptor, DescriptorInfo, DescriptorSet, DriverError,
-            FramebufferAttachmentImageInfo, FramebufferInfo, SharingMode, SubpassDependency,
-            SubpassInfo,
+            AttachmentInfo, AttachmentRef, Descriptor, DescriptorInfo, DriverError,
+            FramebufferAttachmentImageInfo, FramebufferInfo, RawDescriptorSet, SharingMode,
+            SubpassDependency, SubpassInfo,
             accel_struct::AccelerationStructure,
             buffer::{Buffer, BufferSubresourceRange},
             cmd_buf::{CommandBuffer, CommandBufferInfo},
-            descriptor_set::{DescriptorPool, DescriptorPoolInfo},
+            descriptor_set::{DescriptorPool, DescriptorPoolInfo, DescriptorSet},
             device::Device,
             fence::{Fence, FenceDroppable},
             format_aspect_mask,
@@ -896,7 +896,7 @@ struct QueueOwnershipReleaseWait {
 #[derive(Debug, Default)]
 struct CommandRecordingResources {
     descriptor_pool: Option<Lease<DescriptorPool>>,
-    descriptor_sets: Vec<Vec<DescriptorSet>>,
+    descriptor_sets: Vec<Vec<RecordingDescriptorSet>>,
     render_pass: Option<Lease<RenderPass>>,
 }
 
@@ -1244,6 +1244,21 @@ impl<'a> From<(&'a [SemaphoreSubmitInfo], &'a [SemaphoreSubmitInfo])> for QueueS
 impl<'a> From<(&'a [SemaphoreSubmit2Info], &'a [SemaphoreSubmit2Info])> for QueueSubmitInfo<'a> {
     fn from((waits, signals): (&'a [SemaphoreSubmit2Info], &'a [SemaphoreSubmit2Info])) -> Self {
         Self::QueueSubmit2 { waits, signals }
+    }
+}
+
+#[derive(Debug)]
+enum RecordingDescriptorSet {
+    Automatic(RawDescriptorSet),
+    Supplied(DescriptorSet),
+}
+
+impl RecordingDescriptorSet {
+    fn handle(&self) -> vk::DescriptorSet {
+        match self {
+            Self::Automatic(descriptor_set) => **descriptor_set,
+            Self::Supplied(descriptor_set) => descriptor_set.handle(),
+        }
     }
 }
 
@@ -2663,7 +2678,7 @@ impl Submission {
                 descriptor_sets.extend(
                     exec_descriptor_sets
                         .iter()
-                        .map(|descriptor_set| **descriptor_set),
+                        .map(RecordingDescriptorSet::handle),
                 );
 
                 trace!("    bind descriptor sets {:?}", descriptor_sets);
@@ -2763,14 +2778,20 @@ impl Submission {
     where
         P: SubmissionPool,
     {
-        let max_set_idx = pass
+        let max_sets = pass
             .execs
             .iter()
-            .flat_map(|exec| exec.bindings.keys())
-            .map(|descriptor| descriptor.set())
-            .max()
-            .unwrap_or_default();
-        let max_sets = pass.execs.len() as u32 * (max_set_idx + 1);
+            .filter_map(|exec| {
+                exec.pipeline.as_ref().map(|pipeline| {
+                    pipeline
+                        .descriptor_info()
+                        .layouts
+                        .keys()
+                        .filter(|set| !exec.descriptor_sets.contains_key(set))
+                        .count() as u32
+                })
+            })
+            .sum();
         let mut info = DescriptorPoolInfo {
             max_sets,
             ..Default::default()
@@ -2831,8 +2852,8 @@ impl Submission {
             }
         }
 
-        // It's possible to execute a command-only pipeline
-        if info.is_empty() {
+        // It's possible to execute a command-only pipeline or use only supplied descriptor sets.
+        if info.max_sets == 0 {
             return Ok(None);
         }
 
@@ -3580,23 +3601,30 @@ impl Submission {
             let descriptor_pool = Self::lease_descriptor_pool(pool, pass)?;
             let mut descriptor_sets = Vec::with_capacity(pass.execs.len());
             descriptor_sets.resize_with(pass.execs.len(), Vec::new);
-            if let Some(descriptor_pool) = descriptor_pool.as_ref() {
-                for (exec_idx, exec) in pass.execs.iter().enumerate() {
-                    let Some(pipeline) = exec.pipeline.as_ref() else {
-                        continue;
-                    };
+            for (exec_idx, exec) in pass.execs.iter().enumerate() {
+                let Some(pipeline) = exec.pipeline.as_ref() else {
+                    continue;
+                };
 
-                    let layouts = pipeline.descriptor_info().layouts.values();
-                    descriptor_sets[exec_idx] = layouts
-                        .into_iter()
-                        .map(|descriptor_set_layout| {
+                descriptor_sets[exec_idx] = pipeline
+                    .descriptor_info()
+                    .layouts
+                    .iter()
+                    .map(|(&set, descriptor_set_layout)| {
+                        if let Some(descriptor_set) = exec.descriptor_sets.get(&set) {
+                            Ok(RecordingDescriptorSet::Supplied(descriptor_set.clone()))
+                        } else {
+                            let descriptor_pool = descriptor_pool
+                                .as_ref()
+                                .expect("missing automatic descriptor pool");
                             DescriptorPool::allocate_descriptor_set(
                                 descriptor_pool,
                                 descriptor_set_layout,
                             )
-                        })
-                        .collect::<Result<_, _>>()?;
-                }
+                            .map(RecordingDescriptorSet::Automatic)
+                        }
+                    })
+                    .collect::<Result<_, _>>()?;
             }
 
             /*
@@ -3621,8 +3649,11 @@ impl Submission {
                         .inner
                         .descriptor_info
                         .pool_sizes
-                        .values()
-                        .filter_map(|pool| pool.get(&vk::DescriptorType::INPUT_ATTACHMENT))
+                        .iter()
+                        .filter(|(set, _)| {
+                            !pass.expect_first_exec().descriptor_sets.contains_key(set)
+                        })
+                        .filter_map(|(_, pool)| { pool.get(&vk::DescriptorType::INPUT_ATTACHMENT) })
                         .next()
                         .is_none()
             );
@@ -5491,6 +5522,10 @@ impl Submission {
                     );
                     return Err(DriverError::InvalidData);
                 };
+                if exec.descriptor_sets.contains_key(&descriptor_set_idx) {
+                    continue;
+                }
+
                 let descriptor_type = descriptor_info.descriptor_type();
                 let bound_node = &bindings[*node_idx];
                 if let Some(image) = bound_node.as_image() {
@@ -5505,23 +5540,7 @@ impl Submission {
                     let image_layout = match descriptor_type {
                         vk::DescriptorType::COMBINED_IMAGE_SAMPLER
                         | vk::DescriptorType::SAMPLED_IMAGE => {
-                            if image_view_info.aspect_mask.contains(
-                                vk::ImageAspectFlags::DEPTH | vk::ImageAspectFlags::STENCIL,
-                            ) {
-                                vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL
-                            } else if image_view_info
-                                .aspect_mask
-                                .contains(vk::ImageAspectFlags::DEPTH)
-                            {
-                                vk::ImageLayout::DEPTH_READ_ONLY_OPTIMAL
-                            } else if image_view_info
-                                .aspect_mask
-                                .contains(vk::ImageAspectFlags::STENCIL)
-                            {
-                                vk::ImageLayout::STENCIL_READ_ONLY_OPTIMAL
-                            } else {
-                                vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
-                            }
+                            vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
                         }
                         vk::DescriptorType::STORAGE_IMAGE => vk::ImageLayout::GENERAL,
                         _ => {
@@ -5541,7 +5560,7 @@ impl Submission {
                         tls.image_writes.push(IndexedWrite {
                             info_idx: tls.image_infos.len(),
                             write: vk::WriteDescriptorSet {
-                                dst_set: *descriptor_sets[descriptor_set_idx as usize],
+                                dst_set: descriptor_sets[descriptor_set_idx as usize].handle(),
                                 dst_binding,
                                 descriptor_type,
                                 descriptor_count: 1,
@@ -5568,7 +5587,7 @@ impl Submission {
                         tls.buffer_writes.push(IndexedWrite {
                             info_idx: tls.buffer_infos.len(),
                             write: vk::WriteDescriptorSet {
-                                dst_set: *descriptor_sets[descriptor_set_idx as usize],
+                                dst_set: descriptor_sets[descriptor_set_idx as usize].handle(),
                                 dst_binding,
                                 descriptor_type,
                                 descriptor_count: 1,
@@ -5594,7 +5613,7 @@ impl Submission {
                         tls.accel_struct_writes.push(IndexedWrite {
                             info_idx: tls.accel_struct_handles.len(),
                             write: vk::WriteDescriptorSet::default()
-                                .dst_set(*descriptor_sets[descriptor_set_idx as usize])
+                                .dst_set(descriptor_sets[descriptor_set_idx as usize].handle())
                                 .dst_binding(dst_binding)
                                 .descriptor_type(descriptor_type)
                                 .descriptor_count(1),
@@ -5633,6 +5652,10 @@ impl Submission {
                         (descriptor_info, _),
                     ) in &pipeline.inner.descriptor_bindings
                     {
+                        if exec.descriptor_sets.contains_key(&descriptor_set_idx) {
+                            continue;
+                        }
+
                         if let DescriptorInfo::InputAttachment(_, attachment_idx) = *descriptor_info
                         {
                             let current_attachment = exec
@@ -5663,7 +5686,7 @@ impl Submission {
                             tls.image_writes.push(IndexedWrite {
                                 info_idx: tls.image_infos.len(),
                                 write: vk::WriteDescriptorSet {
-                                    dst_set: *descriptor_sets[descriptor_set_idx as usize],
+                                    dst_set: descriptor_sets[descriptor_set_idx as usize].handle(),
                                     dst_binding,
                                     descriptor_type: vk::DescriptorType::INPUT_ATTACHMENT,
                                     descriptor_count: 1,
@@ -6448,6 +6471,8 @@ mod test {
             ash::vk,
             buffer::{Buffer, BufferInfo, BufferSubresourceRange},
             cmd_buf::{CommandBuffer, CommandBufferInfo},
+            compute::{ComputePipeline, ComputePipelineInfo},
+            descriptor_set::{DescriptorSet, DescriptorSetInfo, DescriptorSetUpdateInfo},
             device::{Device, DeviceInfo},
             fence::Fence,
             graphics::{GraphicsPipeline, GraphicsPipelineInfo},
@@ -8279,6 +8304,92 @@ mod test {
             check_queue_submit_args(&waits, &[]),
             Err(DriverError::Unsupported)
         ));
+    }
+
+    #[test]
+    #[ignore = "requires Vulkan device"]
+    fn supplied_descriptor_set_reuses_compatible_pipeline_layout() -> Result<(), DriverError> {
+        let device = test_device()?;
+        let spirv = glsl!(
+            r#"
+            #version 460 core
+            #pragma shader_stage(compute)
+
+            layout(local_size_x = 1) in;
+            layout(set = 0, binding = 0) buffer DataA {
+                uint value;
+            } data_a;
+            layout(set = 1, binding = 0) buffer DataB {
+                uint value;
+            } data_b;
+
+            void main() {
+                data_a.value = 1;
+                data_b.value = 2;
+            }
+            "#
+        );
+        let pipeline =
+            ComputePipeline::create(&device, ComputePipelineInfo::default(), spirv.as_slice())?;
+        let compatible_pipeline =
+            ComputePipeline::create(&device, ComputePipelineInfo::default(), spirv.as_slice())?;
+        let buffer_a = Arc::new(Buffer::create(
+            &device,
+            BufferInfo::device_mem(4, vk::BufferUsageFlags::STORAGE_BUFFER),
+        )?);
+        let buffer_b = Arc::new(Buffer::create(
+            &device,
+            BufferInfo::device_mem(4, vk::BufferUsageFlags::STORAGE_BUFFER),
+        )?);
+        let descriptor_set = DescriptorSet::alloc_and_update(
+            &pipeline,
+            DescriptorSetInfo::builder().set(0),
+            DescriptorSetUpdateInfo::buffer(0, &buffer_a),
+        )?;
+        let descriptor_set_a = DescriptorSet::alloc_and_update(
+            &pipeline,
+            DescriptorSetInfo::builder().set(0),
+            DescriptorSetUpdateInfo::copy(&descriptor_set, 0, 0),
+        )?;
+        let descriptor_set_b = DescriptorSet::alloc_and_update(
+            &pipeline,
+            DescriptorSetInfo::builder().set(1),
+            DescriptorSetUpdateInfo::buffer(0, &buffer_b),
+        )?;
+        drop(descriptor_set);
+        drop(pipeline);
+
+        let mut graph = Graph::new();
+        let buffer_a_node = graph.bind_resource(&buffer_a);
+        let buffer_b_node = graph.bind_resource(&buffer_b);
+        graph
+            .begin_cmd()
+            .bind_pipeline(&compatible_pipeline)
+            .bind_descriptor_set(&descriptor_set_a)
+            .resource_access(buffer_a_node, AccessType::ComputeShaderWrite)
+            .shader_resource_access((1, 0), buffer_b_node, AccessType::ComputeShaderWrite)
+            .record_cmd(|cmd| {
+                cmd.dispatch(1, 1, 1);
+            })
+            .end_cmd();
+        graph
+            .begin_cmd()
+            .bind_pipeline(&compatible_pipeline)
+            .bind_descriptor_set(&descriptor_set_a)
+            .bind_descriptor_set(&descriptor_set_b)
+            .resource_access(buffer_a_node, AccessType::ComputeShaderWrite)
+            .resource_access(buffer_b_node, AccessType::ComputeShaderWrite)
+            .record_cmd(|cmd| {
+                cmd.dispatch(1, 1, 1);
+            })
+            .end_cmd();
+
+        let mut fence = graph
+            .finalize()
+            .queue_submit(&mut HashPool::new(&device), 0, 0)?;
+        fence.wait()?;
+
+        Ok(())
     }
 
     fn test_device() -> Result<TestDevice, DriverError> {


### PR DESCRIPTION
Additive change to allow manually-specified descriptor set writes and copies. This should reduce CPU/driver usage during graph submission for most common workloads. Regular automatic descriptor set usage remains unchanged.

See `examples/bindless.rs` for the change, which is quite minimal. This builds set `0` with a bunch of images bound to descriptor `1`: 
```
let descriptor_set = DescriptorSet::alloc_and_update(
    &pipeline,
    DescriptorSetInfo::builder().set(0).build(),
    images
        .iter()
        .enumerate()
        .map(|(idx, image)| DescriptorSetUpdateInfo::image((1, [idx as u32]), image)),
)?;

...

graph
    .begin_cmd()
    .bind_pipeline(&pipeline)
    .bind_descriptor_set(&descriptor_set)
```

The rest, including declaring access, remains unchanged. I think that could be relaxed in practice, but each program can decide that.